### PR TITLE
Add parentheses to print statement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,9 @@ if IS_WINDOWS:
         import py2exe
         OPTS['console'] = ['pdfmerge.py']
     except ImportError:
-        print '''
+        print('''
 NOTE: If you want to build a Windows executable, you need to download and
 install py2exe from http://sourceforge.net/projects/py2exe/files/py2exe/0.6.9/
-'''
+''')
 
 setup(**OPTS)


### PR DESCRIPTION
Running `pip install pdfmerge` on python3 without py2exe installed leads to an ImportError which then attempts to print: "NOTE: If you want to build a Windows ..."

Instead, it raises a syntax error because the parentheses are missing. That's the case because 2to3 is only used on the source of pdfmerge, not on the setup file.